### PR TITLE
feat: synchronize ademe xlsx files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ bun.lockb
 /.idea/
 /node_modules/
 /duplicate/
+*.iml
+scripts/assets/enums.js
+scripts/assets/tv.js

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,8 @@
         "@commitlint/cz-commitlint": "^19.2.0",
         "@semantic-release/changelog": "^6.0.3",
         "@semantic-release/github": "^10.0.2",
+        "@types/node": "^20.12.4",
+        "deep-object-diff": "^1.1.9",
         "eslint": "^8.57.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-config-standard": "^17.1.0",
@@ -29,7 +31,8 @@
         "jscpd": "^3.5.10",
         "prettier": "^3.2.5",
         "pretty-quick": "^4.0.0",
-        "semantic-release": "^23.0.6"
+        "semantic-release": "^23.0.6",
+        "xlsx": "^0.18.5"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -1893,9 +1896,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.12.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.2.tgz",
-      "integrity": "sha512-zQ0NYO87hyN6Xrclcqp7f8ZbXNbRfoGWNcMvHTPQp9UUrwI0mI7XBz+cu7/W6/VClYo2g63B0cjull/srU7LgQ==",
+      "version": "20.12.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.4.tgz",
+      "integrity": "sha512-E+Fa9z3wSQpzgYQdYmme5X3OTuejnnTx88A6p6vkkJosR3KBz+HpE3kqNm98VE6cfLFcISx7zW7MsJkH6KwbTw==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -1932,6 +1935,15 @@
       "dev": true,
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/adler-32": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
+      "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/agent-base": {
@@ -2406,6 +2418,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/cfb": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
+      "integrity": "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==",
+      "dev": true,
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "crc-32": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -2586,6 +2611,15 @@
       "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
       "dev": true,
       "peer": true,
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/codepage": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
+      "integrity": "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==",
+      "dev": true,
       "engines": {
         "node": ">=0.8"
       }
@@ -2964,6 +2998,18 @@
         "typescript": ">=4"
       }
     },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "dev": true,
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -3204,6 +3250,12 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true
+    },
+    "node_modules/deep-object-diff": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/deep-object-diff/-/deep-object-diff-1.1.9.tgz",
+      "integrity": "sha512-Rn+RuwkmkDwCi2/oXOFS9Gsr5lJZu/yTGpK7wAaAIE75CC+LCGEZHpY6VQJa/RoJcrmaA/docWJZvYohlNkWPA==",
       "dev": true
     },
     "node_modules/defaults": {
@@ -4346,6 +4398,15 @@
       "dev": true,
       "dependencies": {
         "is-callable": "^1.1.3"
+      }
+    },
+    "node_modules/frac": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
+      "integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/from2": {
@@ -10758,6 +10819,18 @@
         "node": ">= 10.x"
       }
     },
+    "node_modules/ssf": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
+      "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
+      "dev": true,
+      "dependencies": {
+        "frac": "~1.1.2"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/stream-combiner2": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
@@ -11414,6 +11487,24 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/wmf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
+      "integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/word": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
+      "integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -11451,6 +11542,27 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
+    },
+    "node_modules/xlsx": {
+      "version": "0.18.5",
+      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.18.5.tgz",
+      "integrity": "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==",
+      "dev": true,
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "cfb": "~1.2.1",
+        "codepage": "~1.15.0",
+        "crc-32": "~1.2.1",
+        "ssf": "~0.11.2",
+        "wmf": "~1.0.1",
+        "word": "~0.3.0"
+      },
+      "bin": {
+        "xlsx": "bin/xlsx.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
     },
     "node_modules/xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "directories": {
     "test": "test"
   },
+  "type": "module",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "qa:lint": "prettier --plugin-search-dir . --check . && eslint .",
@@ -14,7 +15,8 @@
     "qa:format": "prettier --plugin-search-dir . --write .",
     "release": "semantic-release",
     "release:dry": "semantic-release --dry-run",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "assets:sync": "node scripts/synchronize_assets.js"
   },
   "repository": {
     "type": "git",
@@ -34,6 +36,8 @@
     "@commitlint/cz-commitlint": "^19.2.0",
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/github": "^10.0.2",
+    "@types/node": "^20.12.4",
+    "deep-object-diff": "^1.1.9",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-config-standard": "^17.1.0",
@@ -45,7 +49,8 @@
     "jscpd": "^3.5.10",
     "prettier": "^3.2.5",
     "pretty-quick": "^4.0.0",
-    "semantic-release": "^23.0.6"
+    "semantic-release": "^23.0.6",
+    "xlsx": "^0.18.5"
   },
   "author": "Jack Halford",
   "license": "GPL-3.0",

--- a/scripts/synchronize_assets.js
+++ b/scripts/synchronize_assets.js
@@ -1,0 +1,13 @@
+import { SynchronizeAssets } from '../src/core/assets/domain/synchronize-assets.js';
+import { ApplicationConfig } from '../src/core/conf/infrastructure/application.config.js';
+import { SynchronizeEnumTables } from '../src/core/assets/domain/synchronize-enum-tables.js';
+import { FileStore } from '../src/core/file/infrastructure/adapter/file.store.js';
+import { SynchronizeValeurTables } from '../src/core/assets/domain/synchronize-valeur-tables.js';
+
+const fileStore = new FileStore();
+const appConfig = new ApplicationConfig();
+const synchronizeEnumTables = new SynchronizeEnumTables(fileStore, appConfig);
+const synchronizeValeurTables = new SynchronizeValeurTables(fileStore, appConfig);
+const synchronizeAssets = new SynchronizeAssets(synchronizeEnumTables, synchronizeValeurTables);
+
+await synchronizeAssets.execute();

--- a/src/core/assets/domain/synchronize-assets.js
+++ b/src/core/assets/domain/synchronize-assets.js
@@ -1,0 +1,29 @@
+export class SynchronizeAssets {
+  /**
+   * @type {SynchronizeEnumTables}
+   */
+  #synchronizeEnumTables;
+
+  /**
+   * @type {SynchronizeValeurTables}
+   */
+  #synchronizeValeurTables;
+
+  /**
+   * @param synchronizeEnumTables {SynchronizeEnumTables}
+   * @param synchronizeValeurTables {SynchronizeValeurTables}
+   */
+  constructor(synchronizeEnumTables, synchronizeValeurTables) {
+    this.#synchronizeEnumTables = synchronizeEnumTables;
+    this.#synchronizeValeurTables = synchronizeValeurTables;
+  }
+
+  execute() {
+    return Promise.all([
+      this.#synchronizeEnumTables.execute(),
+      this.#synchronizeValeurTables.execute()
+    ])
+      .then(() => console.log('enum and valeur tables are synchronized successfully'))
+      .catch((error) => console.error('Could not synchronize files', error));
+  }
+}

--- a/src/core/assets/domain/synchronize-enum-tables.js
+++ b/src/core/assets/domain/synchronize-enum-tables.js
@@ -1,0 +1,90 @@
+import { diff } from 'deep-object-diff';
+import enums from '../../../enums.js';
+
+/**
+ * Download the `enum_tables.xlsx` file from the official ademe repository and generates a new `enums.js` file
+ * Please see @link https://gitlab.com/observatoire-dpe/observatoire-dpe/-/tree/master
+ * - Convert the file into a json object
+ * - Extract, format data and then generate a new enums.js file
+ */
+export class SynchronizeEnumTables {
+  /**
+   * @type {FileStore}
+   */
+  #fileStore;
+
+  /**
+   * @type {ApplicationConfig}
+   */
+  #appConfig;
+
+  /**
+   * @param fileStore {FileStore}
+   * @param appConfig {ApplicationConfig}
+   */
+  constructor(fileStore, appConfig) {
+    this.#fileStore = fileStore;
+    this.#appConfig = appConfig;
+  }
+
+  /**
+   * @return {Promise<void>}
+   */
+  async execute() {
+    return await this.#fileStore
+      .downloadXlsxFileAndConvertToJson(this.#appConfig.ademeEnumTablesFileUrl)
+      .then(
+        /** @param excelSheets {{[tabName: string]: {id: string, lib: string}[]}} xlsx content file grouped by tab */
+        (excelSheets) => {
+          const enumsOutput = {};
+
+          // for each tab in xlsx file
+          Object.keys(excelSheets)
+            .filter((sheetName) => sheetName !== 'index') // Exclude first tab called "index"
+            .forEach((sheetName) => {
+              /**
+               * Each Excel sheet has a list of columns
+               * Keep only the two first columns for now for compatibility with the legacy `enums.js` file
+               * @type {{id: string, lib: string}[]}
+               */
+              const excelSheetValues = excelSheets[sheetName];
+
+              const outputTabValues = {};
+
+              /**
+               * Convert object in the form of [{id: 1, lib: "test"}, {id: 2, lib: "test 2"}]
+               * to {1: "test", 2: "test 2"}
+               */
+              excelSheetValues.forEach((excelSheetValue) => {
+                outputTabValues[excelSheetValue.id] = excelSheetValue.lib.replace(/ :/g, ' :');
+
+                // For compatibility with the legacy `enums.js` file, force the lowercase for
+                // each value except the `classe_etiquette`
+                if (sheetName !== 'classe_etiquette') {
+                  outputTabValues[excelSheetValue.id] =
+                    outputTabValues[excelSheetValue.id].toLowerCase();
+                }
+              });
+
+              enumsOutput[sheetName] = outputTabValues;
+            });
+
+          // Verify that the generated file has no diff with the legacy `enum.js` file
+          const enumsDiff = diff(enums, enumsOutput);
+
+          if (Object.keys(enumsDiff).length > 0) {
+            console.error(enumsDiff);
+            return Promise.reject(
+              'Enums file from ademe repository is different from legacy file: enum.js'
+            );
+          }
+
+          // Overwrite the enums.js file in filesystem
+          return this.#fileStore.writeFileToLocalSystem(
+            `${this.#appConfig.assetsOutputFolder}/enums.js`,
+            `/** @type {TableEnum} **/\nexport default ${JSON.stringify(enumsOutput, null, 2)}`
+          );
+        }
+      );
+  }
+}

--- a/src/core/assets/domain/synchronize-valeur-tables.js
+++ b/src/core/assets/domain/synchronize-valeur-tables.js
@@ -1,0 +1,100 @@
+import { addedDiff, diff } from 'deep-object-diff';
+import { tvs } from '../../../tv.js';
+import { ObjectUtil } from '../../util/infrastructure/object-util.js';
+
+/**
+ * Download the `valeur_tables.xlsx` file from the official ademe repository and generates a new `enums.js` file
+ * Please see @link https://gitlab.com/observatoire-dpe/observatoire-dpe/-/tree/master
+ * - Convert the file into a json object
+ * - Extract, format data and then generate a new tv.js file
+ */
+export class SynchronizeValeurTables {
+  /**
+   * @type {FileStore}
+   */
+  #fileStore;
+
+  /**
+   * @type {ApplicationConfig}
+   */
+  #appConfig;
+
+  /**
+   * @param fileStore {FileStore}
+   * @param appConfig {ApplicationConfig}
+   */
+  constructor(fileStore, appConfig) {
+    this.#fileStore = fileStore;
+    this.#appConfig = appConfig;
+  }
+
+  /**
+   * @return {Promise<void>}
+   */
+  async execute() {
+    return this.#fileStore
+      .downloadXlsxFileAndConvertToJson(this.#appConfig.ademeValeurTablesFileUrl)
+      .then(
+        /** @param excelSheets {any} xlsx content file grouped by tab */
+        (excelSheets) => {
+          // transform Excel sheets to match actual `tv.js` file
+          excelSheets = ObjectUtil.deepObjectTransform(
+            excelSheets,
+            (key) => {
+              if (key.includes('ditribution')) {
+                // Fix typo in xlsx file
+                return key.replace('ditribution', 'distribution');
+              }
+              return key;
+            },
+            (value, key) => {
+              if (typeof value === 'string') {
+                // ALl value that ends with '%' are replace by value to be compatible with the legacy `tv.js` file
+                if (value.endsWith('%')) {
+                  return `${parseFloat(value.replace('%', '')) / 100}`;
+                }
+                // Remove 'kW' to be compatible with the legacy `tv.js` file
+                if (value.endsWith('kW')) {
+                  return value.replace(/kW/g, '').replace(/\s/g, '');
+                }
+              }
+
+              // By default, the Excel parsing ignore property with 0 value,
+              // so we force it to be compatible with the legacy `tv.js` file
+              if (key === 'q4pa_conv' && Array.isArray(value)) {
+                return value.map((v) => {
+                  if (!v.isolation_surfaces) {
+                    v.isolation_surfaces = '0';
+                  }
+                  return v;
+                });
+              }
+
+              // Reformat all number with only one decimal to be compatible with the legacy `tv.js` file
+              if (!isNaN(Number(value)) && value.endsWith('0') && value.includes('.')) {
+                return `${Math.round(value * 10) / 10}`;
+              }
+
+              return value;
+            }
+          );
+
+          // Some properties exist in the legacy `tv.js` file but not in the Excel file,
+          // so we keep it to be compatible
+          excelSheets = Object.assign({}, excelSheets, addedDiff(excelSheets, tvs));
+          const jsonDiff = diff(tvs, excelSheets);
+
+          if (Object.keys(jsonDiff).length > 0) {
+            console.error(jsonDiff);
+            return Promise.reject('Valeurs file from ademe repository is different from local one');
+          }
+
+          // Overwrite the enum.js file in filesystem
+          return this.#fileStore.writeFileToLocalSystem(
+            `${this.#appConfig.assetsOutputFolder}/tv.js`,
+            `/** @type {TableValeur} **/\nexport const tvs = ${JSON.stringify(tabValues, null, 2)}`
+          );
+        }
+      );
+  }
+}

--- a/src/core/conf/infrastructure/application.config.js
+++ b/src/core/conf/infrastructure/application.config.js
@@ -1,0 +1,20 @@
+export class ApplicationConfig {
+  get ademeRepositoryVersion() {
+    return 'dpe-2.4-audit-2.2';
+  }
+
+  get ademeRepositoryUrl() {
+    return 'https://gitlab.com/observatoire-dpe/observatoire-dpe';
+  }
+
+  get ademeEnumTablesFileUrl() {
+    return `${this.ademeRepositoryUrl}/-/raw/${this.ademeRepositoryVersion}/modele_donnee/enum_tables.xlsx?ref_type=heads&inline=false`;
+  }
+
+  get ademeValeurTablesFileUrl() {
+    return `${this.ademeRepositoryUrl}/-/raw/${this.ademeRepositoryVersion}/modele_donnee/valeur_tables.xlsx?ref_type=heads&inline=false`;
+  }
+  get assetsOutputFolder() {
+    return 'scripts/assets';
+  }
+}

--- a/src/core/file/infrastructure/adapter/file.store.js
+++ b/src/core/file/infrastructure/adapter/file.store.js
@@ -1,0 +1,41 @@
+import { writeFile } from 'fs';
+import * as XLSX from 'xlsx';
+
+export class FileStore {
+  /**
+   * Download a xlsx file and convert it to json
+   *
+   * @param url {string} url of the xlsx file to download and convert
+   *
+   * @return {Promise<any>}
+   */
+  async downloadXlsxFileAndConvertToJson(url) {
+    const buffer = await fetch(url).then((res) => res.arrayBuffer());
+
+    const wb = XLSX.read(buffer, { type: 'string', raw: false });
+
+    const jsonOutput = {};
+    wb.SheetNames.forEach((sheetName) => {
+      jsonOutput[sheetName] = XLSX.utils.sheet_to_json(wb.Sheets[sheetName], { raw: false });
+    });
+
+    return Promise.resolve(jsonOutput);
+  }
+
+  /**
+   * @param filePath {string}
+   * @param content {string}
+   * @return {Promise<void>}
+   */
+  async writeFileToLocalSystem(filePath, content) {
+    return new Promise((resolve, reject) => {
+      writeFile(filePath, content, { encoding: 'utf-8' }, (err) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve();
+        }
+      });
+    });
+  }
+}

--- a/src/core/util/infrastructure/object-util.js
+++ b/src/core/util/infrastructure/object-util.js
@@ -1,0 +1,23 @@
+export class ObjectUtil {
+  /**
+   *  Apply transformation on object properties or nested properties
+   * @param obj {any}
+   * @param keyTransformFn  {(key: string) => string}
+   * @param valueTransformFn {(value: any, key?: string) => string}
+   */
+  static deepObjectTransform(obj, keyTransformFn, valueTransformFn) {
+    return Array.isArray(obj)
+      ? obj.map((val) => ObjectUtil.deepObjectTransform(val, keyTransformFn, valueTransformFn))
+      : typeof obj === 'object'
+        ? Object.keys(obj).reduce((acc, current) => {
+            const key = keyTransformFn(current);
+            const val = valueTransformFn(obj[current], key);
+            acc[key] =
+              val !== null && typeof val === 'object'
+                ? ObjectUtil.deepObjectTransform(val, keyTransformFn, valueTransformFn)
+                : val;
+            return acc;
+          }, {})
+        : obj;
+  }
+}

--- a/src/tv.js
+++ b/src/tv.js
@@ -4655,8 +4655,8 @@ export const tvs = {
       enum_type_generateur_ecs_id: '54|101',
       type_generateur: 'Chaudière gaz à condensation 1981-1985',
       pn: 'Pn',
-      rpn: '91 + 1 logPn',
-      rpint: '97 + 1 logPn',
+      rpn: '91 + logPn',
+      rpint: '97 + logPn',
       qp0_perc: '0.01',
       pveil: '150'
     },
@@ -4666,8 +4666,8 @@ export const tvs = {
       enum_type_generateur_ecs_id: '55|102',
       type_generateur: 'Chaudière gaz à condensation 1986-2000',
       pn: 'Pn',
-      rpn: '91 + 1 logPn',
-      rpint: '97 + 1 logPn',
+      rpn: '91 + logPn',
+      rpint: '97 + logPn',
       pveil: '120'
     },
     {
@@ -4676,8 +4676,8 @@ export const tvs = {
       enum_type_generateur_ecs_id: '56|103|120|132',
       type_generateur: 'Chaudière gaz à condensation 2001-2015',
       pn: 'Pn',
-      rpn: '91 + 1 logPn',
-      rpint: '97 + 1 logPn'
+      rpn: '91 + logPn',
+      rpint: '97 + logPn'
     },
     {
       tv_generateur_combustion_id: '13',
@@ -4797,8 +4797,8 @@ export const tvs = {
       enum_type_generateur_ecs_id: '43|122',
       type_generateur: 'Chaudière fioul à condensation 1996-2015',
       pn: 'Pn',
-      rpn: '91 + 1 logPn',
-      rpint: '97 + 1 logPn',
+      rpn: '91 + logPn',
+      rpint: '97 + logPn',
       qp0_perc: '0.01'
     },
     {
@@ -4819,7 +4819,7 @@ export const tvs = {
       type_generateur: 'Chaudière fioul à condensation après 2015',
       critere_pn: 'Pn≤70',
       pn: 'Pn',
-      rpn: '94 + 1 logPn',
+      rpn: '94 + logPn',
       rpint: '100 + logPn',
       qp0_perc: '0.006'
     },
@@ -5368,7 +5368,7 @@ export const tvs = {
       type_generateur: 'Chauffe-eau gaz à production instantanée avant 1980',
       critere_pn: 'Pn≤10',
       rpn: '70',
-      qp0_perc: '4.0 %',
+      qp0_perc: '0.04',
       pveil: '150'
     },
     {
@@ -5377,7 +5377,7 @@ export const tvs = {
       type_generateur: 'Chauffe-eau gaz à production instantanée 1981-1989',
       critere_pn: 'Pn≤10',
       rpn: '75',
-      qp0_perc: '2.0 %',
+      qp0_perc: '0.02',
       pveil: '120'
     },
     {
@@ -5386,7 +5386,7 @@ export const tvs = {
       type_generateur: 'Chauffe-eau gaz à production instantanée 1990-2000',
       critere_pn: 'Pn≤10',
       rpn: '81',
-      qp0_perc: '1.2 %',
+      qp0_perc: '0.012',
       pveil: '120'
     },
     {
@@ -5395,7 +5395,7 @@ export const tvs = {
       type_generateur: 'Chauffe-eau gaz à production instantanée 2001-2015',
       critere_pn: 'Pn≤10',
       rpn: '82',
-      qp0_perc: '1.0 %',
+      qp0_perc: '0.01',
       pveil: '100'
     },
     {
@@ -5404,7 +5404,7 @@ export const tvs = {
       type_generateur: 'Chauffe-eau gaz à production instantanée après  2015',
       critere_pn: 'Pn≤10',
       rpn: '82',
-      qp0_perc: '1.0 %'
+      qp0_perc: '0.01'
     },
     {
       tv_generateur_combustion_id: '89',
@@ -5412,7 +5412,7 @@ export const tvs = {
       type_generateur: 'Chauffe-eau gaz à production instantanée avant 1980',
       critere_pn: 'Pn>10',
       rpn: '70',
-      qp0_perc: '4.0 %',
+      qp0_perc: '0.04',
       pveil: '150'
     },
     {
@@ -5421,7 +5421,7 @@ export const tvs = {
       type_generateur: 'Chauffe-eau gaz à production instantanée 1981-1989',
       critere_pn: 'Pn>10',
       rpn: '75',
-      qp0_perc: '2.0 %',
+      qp0_perc: '0.02',
       pveil: '120'
     },
     {
@@ -5430,7 +5430,7 @@ export const tvs = {
       type_generateur: 'Chauffe-eau gaz à production instantanée 1990-2000',
       critere_pn: 'Pn>10',
       rpn: '82',
-      qp0_perc: '1.2 %',
+      qp0_perc: '0.012',
       pveil: '120'
     },
     {
@@ -5439,7 +5439,7 @@ export const tvs = {
       type_generateur: 'Chauffe-eau gaz à production instantanée 2001-2015',
       critere_pn: 'Pn>10',
       rpn: '84',
-      qp0_perc: '1.0 %',
+      qp0_perc: '0.01',
       pveil: '100'
     },
     {
@@ -5448,7 +5448,7 @@ export const tvs = {
       type_generateur: 'Chauffe-eau gaz à production instantanée après  2015',
       critere_pn: 'Pn>10',
       rpn: '84',
-      qp0_perc: '0.6 %'
+      qp0_perc: '0.006'
     }
   ],
   intermittence: [
@@ -67082,5 +67082,5 @@ export const tvs = {
       }
     }
   }
-}
-export default tvs
+};
+export default tvs;


### PR DESCRIPTION
Ajout d'un script qui va récupérer les fichiers `enum_tables.xlsx` et `valeur_tables.xslx` sur le repository gitlab de l'ademe (https://gitlab.com/observatoire-dpe/observatoire-dpe/-/tree/master/modele_donnee?ref_type=heads)
Le script permet de:
- Télécharger chaque fichier excel et les parser en JSON
- On applique quelques trasnformations de données
- On génère les fichiers `enum.js` et `tv.js` dans un dossier à part (on écrase donc pas les fichiers existants pour l'instant)
- Pour les deux fichiers on fait une comparaison pour vérifier si le fichier généré est équivalent au fichier initial, si il y a une différence les fichiers ne sont pas générés pour eviter les régressions.

J'en ai profié pour découper le code suivant le principe de la [clean architecture](https://blog.cleancoder.com/uncle-bob/2012/08/13/the-clean-architecture.html) afin d'avoir un premier apercu du découpage du code.

Concernant le fichier `enum.js` je retombe bien sur les mêmes données.
Concernant le fichier `tv.js`, j'ai une différence notable sur : 

```shell
generateur_combustion: {
    '25': { critere_pn: '70<Pn≤400' },`tv_generateur_combustion_id: 26, Excel: 70<Pn≤400, tv.js: Pn<=70`
    '26': { critere_pn: 'Pn>400' },`tv_generateur_combustion_id: 27, Excel: 70<Pn≤400, tv.js: Pn > 400`
  }
```
Pour l'instant le fichier `tv.js` n'est pas généré à cause de cette différence.

Pour lancer la synchronisation, il faut lancer `npm run assets:sync` ce qui va générer les fichiers `enums.js` et `tv.js` dans le dossier `scripts/assets` pour l'instant